### PR TITLE
Do not create a state where an edge would suffice.

### DIFF
--- a/pylexparse/matcher.py
+++ b/pylexparse/matcher.py
@@ -72,8 +72,10 @@ def anything_to_fragment(pat):
 
 @handles(pattern.OneOf)
 def one_of_to_fragment(one_of):
-    equivalent_pattern = pattern.Or(*(char for char in one_of.candidates))
-    return pattern_to_fragment(equivalent_pattern)
+    start, end = nfa.State(), nfa.State()
+    for char in one_of.candidates:
+        start.add_transition(char, end)
+    return nfa.Fragment(start, end)
 
 
 @handles(pattern.Repeat)


### PR DESCRIPTION
Previously, the system generated patterns for OneOf as though it were
an Or.  In turn, it created two new states per character in the OneOf
object.  That meant that the regex '.' was converted to an NFA with
over one hundred states!

Now, instead, a OneOf is represented as a start state and an end state
with many transitions from start to end-- one for each character.

This allows patterns like '.{1000}' to be transformed into NFAs much
more quickly (about 10x faster).
